### PR TITLE
git: copy PR urls even from inside tmux

### DIFF
--- a/tag-git/local/bin/git-create-pull-request
+++ b/tag-git/local/bin/git-create-pull-request
@@ -18,5 +18,12 @@ else
 fi
 
 vim "${vim_flags[@]}" "$msg"
-hub pull-request -m "$(sed '/^#/d' "$msg")" | pbcopy
+
+if [ -n "$TMUX"]; then
+  pbcopy="pbcopy"
+else
+  pbcopy="reattach-to-user-namespace pbcopy"
+fi
+
+hub pull-request -m "$(sed '/^#/d' "$msg")" | "$pbcopy"
 echo "copied: $(pbpaste)"


### PR DESCRIPTION
tmux doesn't play super nicely with macOS, so if we're in a tmux session
we need to use `reattach-to-user-namespace` when copying. If we _don't_
do that, then the `pbcopy` command here fails and we never see the echo
statement that the url was copied (and the url never _is_ copied). To
resolve this we can conditionally use `reattach-to-user-namespace` if
the `TMUX` variable is set.