### PR TITLE
tmux: launch gitsh with reattach-to-user-namespace

### DIFF
--- a/tag-git/config/git/config
+++ b/tag-git/config/git/config
@@ -10,7 +10,6 @@
   program = gpg2
 
 [commit]
-  gpgsign = true
   verbose = true
 
 [alias]

--- a/tag-tmux/config/tmux/keybindings.tmux
+++ b/tag-tmux/config/tmux/keybindings.tmux
@@ -4,7 +4,7 @@ unbind C-s
 bind C-s send-prefix
 
 # Open a temporary split with gitsh
-bind g split-window -h -c '#{pane_current_path}' -p 30 'gitsh'
+bind g split-window -h -c '#{pane_current_path}' -p 30 'reattach-to-user-namespace gitsh'
 
 # reload config
 unbind r


### PR DESCRIPTION
Without this set, when we launch gitsh from tmux we won't have access to
`pbcopy`. This caused our `create-pull-request` script to "fail" in that
it didn't properly copy the url to the clipboard.

I'm also disabling signing my commits for now so that I can rebase this
repo.

(this PR is _basically_ just a test to make sure this all works
properly)